### PR TITLE
Business Casual - Fixed box not clearing 12 column floats on 3.0.3

### DIFF
--- a/templates/business-casual/css/business-casual.css
+++ b/templates/business-casual/css/business-casual.css
@@ -164,3 +164,11 @@ footer p {
 }
 
 }
+
+@media screen and (min-width: 1200px) {
+    .box:after {
+        content: '';
+        display: table;
+        clear: both;
+    }
+}


### PR DESCRIPTION
Bootstrap 3.0.3 reintroduced floating on all 12th column grid tiers. This caused the boxes to display weird when your screen was 1200px+

![](http://puu.sh/5Fysn/9dab5a4223.jpg)
