### PR TITLE
Fixes IronSummitMedia/startbootstrap#27 by adjusting padding.

### DIFF
--- a/templates/sb-admin/css/sb-admin.css
+++ b/templates/sb-admin/css/sb-admin.css
@@ -156,4 +156,9 @@ table.tablesorter thead tr th:hover {
 	white-space: normal;
   }
 
+  .navbar-collapse {
+    padding-left: 15px !important;
+    padding-right: 15px !important;
+  }
+
 }


### PR DESCRIPTION
By adding 15px of left and right `padding` on `.navbar-collapse` the conditions in which the page was originally made are replicated.
Though this may cause other issues, I have not been able to find any.
