### PR TITLE
Fix a typo of Font Awesome icon name

### DIFF
--- a/templates/stylish-portfolio/index.html
+++ b/templates/stylish-portfolio/index.html
@@ -204,7 +204,7 @@
                         </li>
                     </ul>
                     <div class="top-scroll">
-                        <a href="#top"><i class="fa fa-circle-arrow-up scroll fa-4x"></i></a>
+                        <a href="#top"><i class="fa fa-arrow-circle-up scroll fa-4x"></i></a>
                     </div>
                     <hr>
                     <p>Copyright &copy; Company 2013</p>


### PR DESCRIPTION
'fa-circle-arrow-up' would be invalid for Font Awesome 4.0.3.
Use 'fa-arrow-circle-up' instead.
