### PR TITLE
SB Amin 2: Fix minor bug in a CSS rule targeting the wrong selector

### DIFF
--- a/templates/sb-admin-v2/css/sb-admin.css
+++ b/templates/sb-admin-v2/css/sb-admin.css
@@ -239,7 +239,7 @@
 /* DataTables Overrides */
 
  table.dataTable thead .sorting,
-table.dataTable thead .sorting_asc:after,
+table.dataTable thead .sorting_asc,
 table.dataTable thead .sorting_desc,
 table.dataTable thead .sorting_asc_disabled,
 table.dataTable thead .sorting_desc_disabled {


### PR DESCRIPTION
There was a typo when overriding one of the styles from DataTables, causing that style not to be overridden properly.
