### PR TITLE
Use innerWindow as conditional comparison for appending/removing collapse class

### DIFF
--- a/templates/sb-admin-v2/js/sb-admin.js
+++ b/templates/sb-admin-v2/js/sb-admin.js
@@ -8,7 +8,8 @@ $(function() {
 //collapses the sidebar on window resize.
 $(function() {
     $(window).bind("load resize", function() {
-        if (this.window.innerWidth < 768) {
+        width = (this.window.innerWidth > 0) ? this.window.innerWidth : this.screen.width;
+        if (width < 768) {
             $('div.sidebar-collapse').addClass('collapse')
         } else {
             $('div.sidebar-collapse').removeClass('collapse')


### PR DESCRIPTION
When using a desktop browser, the window.width() value being used in the calculation for when to add or remove the collapse the side-nav bar is not exactly accurate.

In bootstrap, the width used for for most 'mobile style' items is 768, which is based on the `window.innerWidth`, which is a few pixels different from the window.width() value. (e.g. in my browser, 768 on `innerWidth` is 754 on `$(this).width`)

This means that when the window is between 768 and ~782 pixels wide, the sidenav for sb-admin is visible, however, the bootstrap UL items are not. This creates a problem (albeit a small one)

By using `window.innerWidth`, the width used to trigger the collapse styles for both sbadmin and bootstrap match, so both show collapsed versions of their items at the same time, without gap in functionality.

I've also extended it to check for mobile-device width defaults (per http://stackoverflow.com/a/6850319/124019)

Also, this branch removes an errant `console.log()` call
