### PR TITLE
Dynamically set min-height to window height

### DIFF
--- a/templates/sb-admin-v2/js/sb-admin.js
+++ b/templates/sb-admin-v2/js/sb-admin.js
@@ -6,13 +6,23 @@ $(function() {
 
 //Loads the correct sidebar on window load,
 //collapses the sidebar on window resize.
+// Sets the min-height of #üpage-wrapper to window size
 $(function() {
     $(window).bind("load resize", function() {
+	   	topOffset=50;
         width = (this.window.innerWidth > 0) ? this.window.innerWidth : this.screen.width;
         if (width < 768) {
             $('div.sidebar-collapse').addClass('collapse')
+            topOffset=100; // 2-row-menu
         } else {
             $('div.sidebar-collapse').removeClass('collapse')
         }
+        
+        height = (this.window.innerHeight > 0) ? this.window.innerHeight : this.screen.height;
+        height=height-topOffset;
+        if (height<1) height=1;
+        if (height>topOffset) {
+        	$("#page-wrapper").css("min-height",(height)+"px");
+    	}
     })
 })


### PR DESCRIPTION
Setting #page-wrapper min-height to window height causes the content to be as least as height as the screen without adding unnecessary scroll bars
