### PR TITLE
fix resources' broken links issue #168

### DIFF
--- a/bootstrap-resources.html
+++ b/bootstrap-resources.html
@@ -321,7 +321,7 @@ meta-description: "Bootstrap resources page meta description goes here."
 						<tr>
 							<td>Jetstrap</td>
 							<td>Not just a mock-up tool, Jetstrap is the premier interface-building tool for Bootstrap 3.</td>
-							<td><a href="http://understrap.com/" class="btn btn-primary btn-sm">View Resource</a></td>
+							<td><a href="http://Jetstrap.com/" class="btn btn-primary btn-sm">View Resource</a></td>
 						</tr>
 						<tr>
 							<td>Roots.io Sage</td>
@@ -331,7 +331,7 @@ meta-description: "Bootstrap resources page meta description goes here."
 						<tr>
 							<td>Understrap</td>
 							<td>UnderStrap combines the Underscores starter theme (by Automattic) and the mobil-first, responsive grid framework Bootstrap (by Twitter) into a perfect open source foundation for your next WordPress theme project.</td>
-							<td><a href="https://jetstrap.com/" class="btn btn-primary btn-sm">View Resource</a></td>
+							<td><a href="http://understrap.com/" class="btn btn-primary btn-sm">View Resource</a></td>
 						</tr>
 						<tr>
 							<td>TwitterBootstrapMVC</td>


### PR DESCRIPTION
fix link to "**Understrap**" "**Jetstrap**" websites in resources > Bootstrap Development Tools.
Fixes #168 