### PR TITLE
Fix Command Error

### DIFF
--- a/assets/vendor/bootstrap/scss/_root.scss
+++ b/assets/vendor/bootstrap/scss/_root.scss
@@ -1,0 +1,19 @@
+:root {
+  // Custom variable values only support SassScript inside `#{}`.
+  @each $color, $value in $colors {
+    --#{"$color"}: #{$value};
+  }
+
+  @each $color, $value in $theme-colors {
+    --#{"$color"}: #{$value};
+  }
+
+  @each $bp, $value in $grid-breakpoints {
+    --breakpoint-#{$bp}: #{$value};
+  }
+
+  // Use `inspect` for lists so that quoted items keep the quotes.
+  // See https://github.com/sass/sass/issues/2383#issuecomment-336349172
+  --font-family-sans-serif: #{inspect($font-family-sans-serif)};
+  --font-family-monospace: #{inspect($font-family-monospace)};
+}


### PR DESCRIPTION
Example error on command:
```WARNING on line 4, column 7 of D:/aportfolio/startbootstrap/assets/vendor/bootstrap/scss/_root.scss:
You probably don't mean to use the color value `gray' in interpolation here.
It may end up represented as #808080, which will likely produce invalid CSS.
Always quote color names when using them as strings (for example, "gray").
If you really want to use the color value here, use `"" + $color'.```